### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/middlewares/renderer/renderer.go
+++ b/middlewares/renderer/renderer.go
@@ -22,13 +22,13 @@ type Renderer struct {
 	DefaultRenderType string
 }
 
-// New( Returns a new Renderer object
+// New Returns a new Renderer object
 func New(options *Options, defaultRenderType string) *Renderer {
 	r := render.New(render.Options(*options))
 	return &Renderer{r, options, defaultRenderType}
 }
 
-// HandlerWithNext Returns a middleware HandlerFunc that saves the Render object into request context
+// Handler Returns a middleware HandlerFunc that saves the Render object into request context
 func (renderer *Renderer) Handler(w http.ResponseWriter, req *http.Request, next http.HandlerFunc, ctx domain.IContext) {
 	SetRendererCtx(ctx, req, renderer)
 	next(w, req)


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._
